### PR TITLE
Add `available()`

### DIFF
--- a/src/ArduinoCI/File_CI.cpp
+++ b/src/ArduinoCI/File_CI.cpp
@@ -35,6 +35,10 @@ File_CI::File_CI(file_ci *file, oflag_t oflag) {
   }
 }
 
+int File_CI::available() const {
+  return this->size() - this->position();
+}
+
 uint32_t File_CI::available32() const {
   return this->size() - this->position();
 }

--- a/src/ArduinoCI/SD_CI.h
+++ b/src/ArduinoCI/SD_CI.h
@@ -37,6 +37,7 @@ public:
 class File_CI {
 public:
   File_CI(file_ci *file = nullptr, oflag_t oflag = 0x00);
+  int available() const;
   uint32_t available32() const;
   bool close();
   void flush();

--- a/test/File_CI_test.cpp
+++ b/test/File_CI_test.cpp
@@ -40,6 +40,12 @@ unittest(append) {
   assertEqual("In the beginning God created the heavens and the earth.", bytes);
 }
 
+unittest(available) {
+  assertEqual(0, file.position());
+  assertEqual(20, file.size());
+  assertEqual(20, file.available());
+}
+
 unittest(available32) {
   assertEqual(0, file.position());
   assertEqual(20, file.size());


### PR DESCRIPTION
We used to use `available32()` but it seems to no longer be present.